### PR TITLE
Se soluciona error por esperar archivo styles

### DIFF
--- a/exercises/03-Inline-Styles/tests.js
+++ b/exercises/03-Inline-Styles/tests.js
@@ -1,7 +1,6 @@
 const fs = require("fs");
 const path = require("path");
 const html = fs.readFileSync(path.resolve(__dirname, "./index.html"), "utf8");
-const css = fs.readFileSync(path.resolve(__dirname, "./styles.css"), "utf8");
 
 jest.dontMock("fs");
 
@@ -13,18 +12,9 @@ describe("The Table tag should contain inline style background: green", function
   afterEach(() => {
     jest.resetModules();
   });
-  it("The styles.css file should be empty", function() {
-    expect(css.toString() === "").toBeTruthy();
-  });
- it("You should not change the head tag", function () {
 
-    let meta1 = document.getElementsByTagName('head')[0].innerHTML.toString().indexOf("<meta c")
-    let meta2 = document.getElementsByTagName('head')[0].innerHTML.toString().indexOf("<meta n")
-    let link = document.getElementsByTagName('head')[0].innerHTML.toString().indexOf("<link")
+ it("You should not change the head tag", function () {
     let title = document.getElementsByTagName('head')[0].innerHTML.toString().indexOf("<title")
-    expect(meta1).not.toBe(-1)
-    expect(meta2).not.toBe(-1)
-    expect(link).not.toBe(-1)
     expect(title).not.toBe(-1)
     expect(html.toString().indexOf(`<style`)>-1).toBeFalsy();
   })


### PR DESCRIPTION
Se quita la validación de que exista el archivo styles.css ya que no es necesario y se quitan validaciones de etiquetas del head que no estaban en el archivo index.html