### PR TITLE
Reemplaza

### DIFF
--- a/exercises/04.2-Apply-several-classes/README.es.md
+++ b/exercises/04.2-Apply-several-classes/README.es.md
@@ -15,7 +15,7 @@ Hay dos posibles clases de palos/pintas que puedes aplicar al elemento html y ha
 
 ## 📝 Instrucciones:
 
-Remmplaza la propiedad `spades` de la clase del `<div>` por la clase `heart` y observa los resultados.
+Reemplaza la propiedad `spades` de la clase del `<div>` por la clase `heart` y observa los resultados.
 
 
 ## Resultado:


### PR DESCRIPTION
Se corrige el archivo README.es.md del ejercicio 4.2, la palabra "Reemplaza" estaba mal escrita.