### PR TITLE
Update .gitpod.Dockerfile to include new Learnpack CLI

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,5 +3,4 @@ FROM gitpod/workspace-full:latest
 
 USER gitpod
 
-RUN npm i jest@24.8.0 -g
-RUN npm i @learnpack/learnpack@2.1.26 -g && learnpack plugins:install learnpack-html@0.0.20
+RUN npm i jest@24.8.0 -g && npm i @learnpack/learnpack@2.1.35 -g && learnpack plugins:install learnpack-html@0.0.20


### PR DESCRIPTION
It's returning an error to students because it has the new coding ide, but with the previous learnpack cli on gitpod